### PR TITLE
Battlefield positioning updates

### DIFF
--- a/src/logic/battle.js
+++ b/src/logic/battle.js
@@ -163,8 +163,8 @@ function setStartPositions(battlefield) {
 	let someoneMoved = false;
 	do {
 		someoneMoved = false;
-		if (advancePositions(battlefield.defense, battlefield.offense, battlefield.skillQueue)) someoneMoved = true;
 		if (advancePositions(battlefield.offense, battlefield.defense, battlefield.skillQueue)) someoneMoved = true;
+		if (advancePositions(battlefield.defense, battlefield.offense, battlefield.skillQueue)) someoneMoved = true;
 	} while (someoneMoved);
 }
 

--- a/src/logic/battle.js
+++ b/src/logic/battle.js
@@ -129,19 +129,20 @@ function getSortedActors(unitConfigs) {
 }
 
 const LIMA_ID = 105201;
+const BASE_SPACING = 605;
 
 function setStartPositions(battlefield) {
 	let missingOffense = 5 - battlefield.offense.length;
 	let missingDefense = 5 - battlefield.defense.length;
 	battlefield.offense.forEach(function(actor, i) {
-		actor.position = 604 + 200 * (i + missingOffense);
+		actor.position = BASE_SPACING + 200 * (i + missingOffense);
 		if (getUnitType(actor.config.id) === "boss") {
 			// Bosses have larger "attack widths"?
 			actor.position -= 300;
 		}
 	});
 	battlefield.defense.forEach(function(actor, i) {
-		actor.position = 604 + 200 * (i + missingDefense);
+		actor.position = BASE_SPACING + 200 * (i + missingDefense);
 		if (getUnitType(actor.config.id) === "boss") {
 			actor.position -= 300;
 		}


### PR DESCRIPTION
Predicts the same Saren distance for the anomalous tie situations vs. Pecorine enemy tank, except one instance is no longer a tie.

* Kaori, Saren, Shiori, Maho, Yui = predicted not a tie, Kaori gets TP because Kaori is closer
* Pecorine, Saren, Rino, Maho, Yui = predicted tie, Pecorine gets TP
* Kuka, Kaori, Saren, Shiori, Yui = predicted tie, Shiori gets TP
* Kuka, Pecorine, Saren, Rino, Yui = predicted tie, Rino gets TP
* Miyako, Kuka, Pecorine, Saren, Suzume = predicted tie, Suzume gets TP

In case it helps you figure things out, I fought against a Lima, Makoto, Eriko, Hatsune, Yui team in dungeon, and so I did some additional testing to see who Saren gives TP to when she's in second slot against enemy Lima, and unlike enemy Pecorine, it's not necessarily the unit in front of her.

* Pecorine, Saren, Rino, Maho, Yui = predicted tie, Rino gets TP
* Kaori, Saren, Suzume, Maho, Yui = predicted tie, Suzume gets TP
* Kuka, Pecorine, Saren, Suzume, Maho = predicted tie, Suzume gets TP
* Miyako, Kuka, Kaori, Saren, Suzume = predicted tie, Suzume gets TP