### PR TITLE
`jp-history/*`: User adjustable EN schedule offset

### DIFF
--- a/src/components/DopeAssTable.svelte
+++ b/src/components/DopeAssTable.svelte
@@ -99,7 +99,11 @@
 		<tr>
 		{#each columns as column}
 			<th class="heading" class:top={!!column.helpText} on:click={changeSort(column)}>
-				{column.displayName}
+				{#if column.html}
+					{@html column.displayName}
+				{:else}
+					{column.displayName}
+				{/if}
 				{#if sort.attr === column.attr}
 					{#if sort.ascending}
 					▲
@@ -174,10 +178,10 @@ div.table-wrap {
 /*	background:
 		linear-gradient(white 30%, rgba(255,255,255,0)),
 		linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
-		
+
 		linear-gradient(rgba(22,59,90,0.25) 0%, rgba(22,59,90,0)),
 		linear-gradient(rgba(22,59,90,0), rgba(22,59,90,0.25) 100%) 0 100%;
-	
+
 	background-repeat: no-repeat;
 	background-size: 100% 50px, 100% 50px, 100% 15px, 100% 15px;
 	background-attachment: local, local, scroll, scroll;

--- a/src/components/Settings.svelte
+++ b/src/components/Settings.svelte
@@ -1,5 +1,5 @@
 <script>
-	import { includeExSkillStats, hideImpossibleRarities, dataSource, theme } from "@src/settings.js";
+	import { includeExSkillStats, hideImpossibleRarities, enScheduleOffset, dataSource, theme } from "@src/settings.js";
 	import { getAssetVersions, SERVER_OPTIONS } from "@src/data";
 	import { onMount, onDestroy } from "svelte";
 	import { closeModal } from "@src/components/Modal.svelte";
@@ -146,6 +146,21 @@
 			</select>
 		</td></tr>
 	</table>
+
+	<h3>EN Schedule Offsets</h3>
+	<table>
+		<tr><td>Banner:</td><td><input bind:value={$enScheduleOffset.banner} type="number" size="2"> days</td></tr>
+		<tr><td>Quest:</td><td><input bind:value={$enScheduleOffset.quest} type="number" size="2"> days</td></tr>
+		<tr><td>Feature:</td><td><input bind:value={$enScheduleOffset.feature} type="number" size="2"> days</td></tr>
+		<tr><td>Dungeon:</td><td><input bind:value={$enScheduleOffset.dungeon} type="number" size="2"> days</td></tr>
+		<tr><td>Grotto:</td><td><input bind:value={$enScheduleOffset.grotto} type="number" size="2"> days</td></tr>
+		<tr><td>Shards:</td><td><input bind:value={$enScheduleOffset.shards} type="number" size="2"> days</td></tr>
+		<tr><td>Arena Shuffle:</td><td><input bind:value={$enScheduleOffset.arenaShuffle} type="number" size="2"> days</td></tr>
+		<tr><td>Furniture Level Cap:</td><td><input bind:value={$enScheduleOffset.furnitureLevelCap} type="number" size="2"> days</td></tr>
+		<tr><td>Six Stars:</td><td><input bind:value={$enScheduleOffset.sixStars} type="number" size="2"> days</td></tr>
+		<tr><td>Unique Equipment:</td><td><input bind:value={$enScheduleOffset.uniqueEquipment} type="number" size="2"> days</td></tr>
+	</table>
+
 	<div class="button" on:click={closeModal}>OK</div>
 </div>
 

--- a/src/routes/jp-history/characters.svelte
+++ b/src/routes/jp-history/characters.svelte
@@ -1,7 +1,7 @@
 <script>
 	import { jpContentHistory } from "@src/data";
 	import { getUnlockedUnits, getUnitImg } from "@src/logic";
-	import { escAttr } from "@src/utils";
+	import { escAttr, formatDate } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import DataComponent from "@src/components/DataComponent.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
@@ -13,6 +13,7 @@
 	let unlockedIds = [];
 
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
+	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
 	$: data = getData(hideUnlockedUnits);
 
@@ -32,12 +33,23 @@
 			sort: "default"
 		}, {
 			attr: "jpDate",
-			displayName: "JP Release Date",
+			displayName: "JP Release Date‎",
 			sort: "default"
 		}, {
+			html: true,
 			attr: "jpDaysAfterLaunch",
-			displayName: "Days After JP Launch",
+			displayName: "Days since<br/>JP Launch",
 			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN<br/>Release Date",
+			sort: "default"
 		}
 	];
 
@@ -53,13 +65,20 @@
 			if (unitAdded.unitId > -1) {
 				iconHtml = "<img class=\"table-icon\" src=\"" + escAttr(getUnitImg(unitAdded.unitId, { rarity: 3, server: "jp" })) + "\" />";
 			}
-			
+
+			const jpDaysAfterLaunch = Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
 			return {
 				icon: iconHtml,
 				name: unitAdded.name,
 				pool: capitalize(unitAdded.pool),
-				jpDate: unitAdded.jpDate,
-				jpDaysAfterLaunch: Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)
+				jpDate: formatDate(new Date(unitAdded.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
 			}
 		});
 	}

--- a/src/routes/jp-history/characters.svelte
+++ b/src/routes/jp-history/characters.svelte
@@ -1,7 +1,8 @@
 <script>
 	import { jpContentHistory } from "@src/data";
 	import { getUnlockedUnits, getUnitImg } from "@src/logic";
-	import { escAttr, formatDate } from "@src/utils";
+	import { enScheduleOffset } from "@src/settings.js";
+	import { escAttr, formatDate, determineOffsetWord } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import DataComponent from "@src/components/DataComponent.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
@@ -15,7 +16,7 @@
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
 	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
-	$: data = getData(hideUnlockedUnits);
+	$: data = getData(hideUnlockedUnits, $enScheduleOffset.banner);
 
 	let columns = [
 		{
@@ -53,7 +54,7 @@
 		}
 	];
 
-	function getData(hideUnlockedUnits) {
+	function getData(hideUnlockedUnits, offset = $enScheduleOffset.banner) {
 		let unitsAdded = jpContentHistory.units;
 		if (hideUnlockedUnits) {
 			unitsAdded = jpContentHistory.units.filter(function(unitAdded) {
@@ -68,7 +69,7 @@
 
 			const jpDaysAfterLaunch = Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + offset;
 			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 			return {
@@ -97,7 +98,8 @@
 
 <h2>JP Characters Added Timeline</h2>
 <DataComponent requiredTables={requiredTables} onDataReady={onDataReady} >
-	<JPContentHeader />
+	<JPContentHeader/>
+	<p>This page assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.banner)}</strong> by <strong>{Math.abs($enScheduleOffset.banner)}</strong> days.</p>
 
 	<p><input type="checkbox" bind:checked={hideUnlockedUnits} /> Hide characters that are in current data source</p>
 

--- a/src/routes/jp-history/features.svelte
+++ b/src/routes/jp-history/features.svelte
@@ -1,9 +1,12 @@
 <script>
 	import { jpContentHistory } from "@src/data/priconnedb";
+	import { formatDate } from "@src/utils";
+	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
 
-	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
+		const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
+		const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
 	function getArenaName(arena) {
 		if (arena === "arena") return "Arena";
@@ -18,6 +21,278 @@
 		"clanBattle": "Clan Battle",
 		"master": "Master"
 	}
+
+	// Feature
+	const featureColumns = [
+		{
+			attr: "feature",
+			displayName: "Feature",
+			sort: "default"
+		}, {
+			attr: "jpDate",
+			displayName: "JP Release Date‎",
+			sort: "default"
+		}, {
+			html: true,
+			attr: "jpDaysAfterLaunch",
+			displayName: "Days since JP Launch",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN Release Date",
+			sort: "default"
+		}
+	];
+	const featureData = (() => {
+		return jpContentHistory.features.map(feature => {
+			const jpDaysAfterLaunch = Math.round((new Date(feature.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
+			return {
+				feature: feature.description,
+				jpDate: formatDate(new Date(feature.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
+			};
+		});
+	})();
+
+	// Dungeon
+	const dungeonColumns = [
+		{
+			attr: "dungeon",
+			displayName: "Dungeon",
+			sort: "default"
+		}, {
+			attr: "jpDate",
+			displayName: "JP Release Date‎",
+			sort: "default"
+		}, {
+			html: true,
+			attr: "jpDaysAfterLaunch",
+			displayName: "Days since<br/>JP Launch",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN<br/>Release Date",
+			sort: "default"
+		}
+	];
+	const dungeonData = (() => {
+		return jpContentHistory.dungeon.map(dungeon => {
+			const jpDaysAfterLaunch = Math.round((new Date(dungeon.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
+			return {
+				dungeon: dungeon.level,
+				jpDate: formatDate(new Date(dungeon.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
+			};
+		});
+	})();
+
+ 	// Grotto
+	const grottoColumns = [
+		{
+			attr: "grotto",
+			displayName: "Grotto Level",
+			sort: "default"
+		}, {
+			attr: "jpDate",
+			displayName: "JP Release Date‎",
+			sort: "default"
+		}, {
+			html: true,
+			attr: "jpDaysAfterLaunch",
+			displayName: "Days since<br/>JP Launch",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN<br/>Release Date",
+			sort: "default"
+		}
+	];
+	const grottoData = (() => {
+		return jpContentHistory.grotto.map(grotto => {
+			const jpDaysAfterLaunch = Math.round((new Date(grotto.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
+			return {
+				grotto: grotto.level,
+				jpDate: formatDate(new Date(grotto.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
+			};
+		});
+	})();
+
+	// Shards in Shop
+	const shardColumns = [
+		{
+			attr: "character",
+			displayName: "Character",
+			sort: "default"
+		}, {
+			attr: "shop",
+			displayName: "Shop",
+			sort: "default"
+		}, {
+			attr: "jpDate",
+			displayName: "JP Release Date‎",
+			sort: "default"
+		}, {
+			html: true,
+			attr: "jpDaysAfterLaunch",
+			displayName: "Days since<br/>JP Launch",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN<br/>Release Date",
+			sort: "default"
+		}
+	];
+	const shardData = (() => {
+		return jpContentHistory.shardsInShop.map(shard => {
+			const jpDaysAfterLaunch = Math.round((new Date(shard.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
+			return {
+				character: shard.name,
+				shop: shopDisplayNames[shard.shop],
+				jpDate: formatDate(new Date(shard.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
+			};
+		});
+	})();
+
+	// Arena Shuffles
+	const arenaShuffleColumns = [
+		{
+			attr: "name",
+			displayName: "Arena Name",
+			sort: "default"
+		}, {
+			attr: "jpDate",
+			displayName: "JP Date‎",
+			sort: "default"
+		}, {
+			html: true,
+			attr: "jpDaysAfterLaunch",
+			displayName: "Days since<br/>JP Launch",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Shuffle",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN Date",
+			sort: "default"
+		}
+	];
+	const arenaShuffleData = (() => {
+		return jpContentHistory.arenaShuffle.map(arenaShuffle => {
+			const jpDaysAfterLaunch = Math.round((new Date(arenaShuffle.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
+			return {
+				name: getArenaName(arenaShuffle.type),
+				jpDate: formatDate(new Date(arenaShuffle.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
+			};
+		});
+	})();
+
+
+	// Furniture
+	const furnitureLevelColumns = [
+		{
+			attr: "furnitureLevelCap",
+			displayName: "Furniture Level Cap",
+			sort: "default"
+		}, {
+			attr: "jpDate",
+			displayName: "JP Date‎",
+			sort: "default"
+		}, {
+			html: true,
+			attr: "jpDaysAfterLaunch",
+			displayName: "Days since<br/>JP Launch",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Shuffle",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN Date",
+			sort: "default"
+		}
+	];
+	const furnitureLevelData = (() => {
+		return jpContentHistory.furnitureLevelCap.map(furnitureLevel => {
+			const jpDaysAfterLaunch = Math.round((new Date(furnitureLevel.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
+			return {
+				furnitureLevelCap: furnitureLevel.level,
+				jpDate: formatDate(new Date(furnitureLevel.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
+			};
+		});
+	})();
+
+
 </script>
 
 <h2>JP Misc Features Timeline</h2>
@@ -25,77 +300,22 @@
 <JPContentHeader />
 
 <h3>Features</h3>
-<table class="info-table">
-	<tr><th>Feature</th><th>JP Release Date</th><th>Days After JP Launch</th></tr>
-	{#each jpContentHistory.features as releaseData, i}
-	<tr class:even={i % 2 === 0}>
-		<td>{releaseData.description}</td>
-		<td>{releaseData.jpDate}</td>
-		<td>{Math.round((new Date(releaseData.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)}</td>
-	</tr>
-	{/each}
-</table>
+<DopeAssTable data={featureData} columns={featureColumns} scroll={false} />
 
 <h3>Dungeons</h3>
-<table class="info-table">
-	<tr><th>Dungeon</th><th>JP Release Date</th><th>Days After JP Launch</th></tr>
-	{#each jpContentHistory.dungeon as releaseData, i}
-	<tr class:even={i % 2 === 0}>
-		<td>{releaseData.level}</td>
-		<td>{releaseData.jpDate}</td>
-		<td>{Math.round((new Date(releaseData.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)}</td>
-	</tr>
-	{/each}
-</table>
+<DopeAssTable data={dungeonData} columns={dungeonColumns} scroll={false} />
 
 <h3>Grotto Quests</h3>
-<table class="info-table">
-	<tr><th>Grotto Level</th><th>JP Release Date</th><th>Days After JP Launch</th></tr>
-	{#each jpContentHistory.grotto as releaseData, i}
-	<tr class:even={i % 2 === 0}>
-		<td>{releaseData.level}</td>
-		<td>{releaseData.jpDate}</td>
-		<td>{Math.round((new Date(releaseData.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)}</td>
-	</tr>
-	{/each}
-</table>
+<DopeAssTable data={grottoData} columns={grottoColumns} scroll={false} />
 
 <h3>Shards in Shop</h3>
-<table class="info-table">
-	<tr><th>Character</th><th>Shop</th><th>JP Release Date</th><th>Days After JP Launch</th></tr>
-	{#each jpContentHistory.shardsInShop as releaseData, i}
-	<tr class:even={i % 2 === 0}>
-		<td>{releaseData.name}</td>
-		<td>{shopDisplayNames[releaseData.shop]}</td>
-		<td>{releaseData.jpDate}</td>
-		<td>{Math.round((new Date(releaseData.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)}</td>
-	</tr>
-	{/each}
-</table>
+<DopeAssTable data={shardData} columns={shardColumns} scroll={false} />
 
 <h3>Arena Shuffles</h3>
-<table class="info-table">
-	<tr><th>Arena</th><th>JP Date</th><th>Days After JP Launch</th></tr>
-	{#each jpContentHistory.arenaShuffle as releaseData, i}
-	<tr class:even={i % 2 === 0}>
-		<td>{getArenaName(releaseData.type)}</td>
-		<td>{releaseData.jpDate}</td>
-		<td>{Math.round((new Date(releaseData.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)}</td>
-	</tr>
-	{/each}
-</table>
+<DopeAssTable data={arenaShuffleData} columns={arenaShuffleColumns} scroll={false} />
 
 <h3>Furniture Levels</h3>
-<table class="info-table">
-	<tr><th>Furniture Level Cap</th><th>JP Release Date</th><th>Days After JP Launch</th></tr>
-	{#each jpContentHistory.furnitureLevelCap as releaseData, i}
-	<tr class:even={i % 2 === 0}>
-		<td>{releaseData.level}</td>
-		<td>{releaseData.jpDate}</td>
-		<td>{Math.round((new Date(releaseData.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)}</td>
-	</tr>
-	{/each}
-</table>
+<DopeAssTable data={furnitureLevelData} columns={furnitureLevelColumns} scroll={false} />
 
 <JPContentFooter />
 

--- a/src/routes/jp-history/features.svelte
+++ b/src/routes/jp-history/features.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { jpContentHistory } from "@src/data/priconnedb";
-	import { formatDate } from "@src/utils";
+	import { enScheduleOffset } from "@src/settings.js";
+	import { formatDate, determineOffsetWord } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
@@ -49,10 +50,10 @@
 			sort: "default"
 		}
 	];
-	const featureData = jpContentHistory.features.map(feature => {
+	$: featureData = jpContentHistory.features.map(feature => {
 		const jpDaysAfterLaunch = Math.round((new Date(feature.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + $enScheduleOffset.feature;
 		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 		return {
@@ -91,10 +92,10 @@
 			sort: "default"
 		}
 	];
-	const dungeonData = jpContentHistory.dungeon.map(dungeon => {
+	$: dungeonData = jpContentHistory.dungeon.map(dungeon => {
 		const jpDaysAfterLaunch = Math.round((new Date(dungeon.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + $enScheduleOffset.dungeon;
 		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 		return {
@@ -133,10 +134,10 @@
 			sort: "default"
 		}
 	];
-	const grottoData = jpContentHistory.grotto.map(grotto => {
+	$: grottoData = jpContentHistory.grotto.map(grotto => {
 		const jpDaysAfterLaunch = Math.round((new Date(grotto.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + $enScheduleOffset.grotto;
 		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 		return {
@@ -179,10 +180,10 @@
 			sort: "default"
 		}
 	];
-	const shardData = jpContentHistory.shardsInShop.map(shard => {
+	$: shardData = jpContentHistory.shardsInShop.map(shard => {
 		const jpDaysAfterLaunch = Math.round((new Date(shard.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + $enScheduleOffset.shards;
 		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 		return {
@@ -222,10 +223,10 @@
 			sort: "default"
 		}
 	];
-	const arenaShuffleData = jpContentHistory.arenaShuffle.map(arenaShuffle => {
+	$: arenaShuffleData = jpContentHistory.arenaShuffle.map(arenaShuffle => {
 		const jpDaysAfterLaunch = Math.round((new Date(arenaShuffle.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + $enScheduleOffset.arenaShuffle;
 		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 		return {
@@ -236,7 +237,6 @@
 			enReleaseDate: formatDate(enReleaseDate),
 		};
 	});
-
 
 	// Furniture
 	const furnitureLevelColumns = [
@@ -265,10 +265,10 @@
 			sort: "default"
 		}
 	];
-	const furnitureLevelData = jpContentHistory.furnitureLevelCap.map(furnitureLevel => {
+	$: furnitureLevelData = jpContentHistory.furnitureLevelCap.map(furnitureLevel => {
 		const jpDaysAfterLaunch = Math.round((new Date(furnitureLevel.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + $enScheduleOffset.furnitureLevelCap;
 		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 		return {
@@ -288,21 +288,27 @@
 <JPContentHeader />
 
 <h3>Features</h3>
+<p>The following table assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.feature)}</strong> by <strong>{Math.abs($enScheduleOffset.feature)}</strong> days.</p>
 <DopeAssTable data={featureData} columns={featureColumns} scroll={false} />
 
 <h3>Dungeons</h3>
+<p>The following table assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.dungeon)}</strong> by <strong>{Math.abs($enScheduleOffset.dungeon)}</strong> days.</p>
 <DopeAssTable data={dungeonData} columns={dungeonColumns} scroll={false} />
 
 <h3>Grotto Quests</h3>
+<p>The following table assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.grotto)}</strong> by <strong>{Math.abs($enScheduleOffset.grotto)}</strong> days.</p>
 <DopeAssTable data={grottoData} columns={grottoColumns} scroll={false} />
 
 <h3>Shards in Shop</h3>
+<p>The following table assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.shards)}</strong> by <strong>{Math.abs($enScheduleOffset.shards)}</strong> days.</p>
 <DopeAssTable data={shardData} columns={shardColumns} scroll={false} />
 
 <h3>Arena Shuffles</h3>
+<p>The following table assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.arenaShuffle)}</strong> by <strong>{Math.abs($enScheduleOffset.arenaShuffle)}</strong> days.</p>
 <DopeAssTable data={arenaShuffleData} columns={arenaShuffleColumns} scroll={false} />
 
 <h3>Furniture Levels</h3>
+<p>The following table assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.furnitureLevelCap)}</strong> by <strong>{Math.abs($enScheduleOffset.furnitureLevelCap)}</strong> days.</p>
 <DopeAssTable data={furnitureLevelData} columns={furnitureLevelColumns} scroll={false} />
 
 <JPContentFooter />

--- a/src/routes/jp-history/features.svelte
+++ b/src/routes/jp-history/features.svelte
@@ -49,22 +49,20 @@
 			sort: "default"
 		}
 	];
-	const featureData = (() => {
-		return jpContentHistory.features.map(feature => {
-			const jpDaysAfterLaunch = Math.round((new Date(feature.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
-			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+	const featureData = jpContentHistory.features.map(feature => {
+		const jpDaysAfterLaunch = Math.round((new Date(feature.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
-			return {
-				feature: feature.description,
-				jpDate: formatDate(new Date(feature.jpDate)),
-				jpDaysAfterLaunch,
-				enDaysToRelease,
-				enReleaseDate: formatDate(enReleaseDate),
-			};
-		});
-	})();
+		return {
+			feature: feature.description,
+			jpDate: formatDate(new Date(feature.jpDate)),
+			jpDaysAfterLaunch,
+			enDaysToRelease,
+			enReleaseDate: formatDate(enReleaseDate),
+		};
+	});
 
 	// Dungeon
 	const dungeonColumns = [
@@ -93,22 +91,20 @@
 			sort: "default"
 		}
 	];
-	const dungeonData = (() => {
-		return jpContentHistory.dungeon.map(dungeon => {
-			const jpDaysAfterLaunch = Math.round((new Date(dungeon.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
-			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+	const dungeonData = jpContentHistory.dungeon.map(dungeon => {
+		const jpDaysAfterLaunch = Math.round((new Date(dungeon.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
-			return {
-				dungeon: dungeon.level,
-				jpDate: formatDate(new Date(dungeon.jpDate)),
-				jpDaysAfterLaunch,
-				enDaysToRelease,
-				enReleaseDate: formatDate(enReleaseDate),
-			};
-		});
-	})();
+		return {
+			dungeon: dungeon.level,
+			jpDate: formatDate(new Date(dungeon.jpDate)),
+			jpDaysAfterLaunch,
+			enDaysToRelease,
+			enReleaseDate: formatDate(enReleaseDate),
+		};
+	});
 
  	// Grotto
 	const grottoColumns = [
@@ -137,22 +133,20 @@
 			sort: "default"
 		}
 	];
-	const grottoData = (() => {
-		return jpContentHistory.grotto.map(grotto => {
-			const jpDaysAfterLaunch = Math.round((new Date(grotto.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
-			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+	const grottoData = jpContentHistory.grotto.map(grotto => {
+		const jpDaysAfterLaunch = Math.round((new Date(grotto.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
-			return {
-				grotto: grotto.level,
-				jpDate: formatDate(new Date(grotto.jpDate)),
-				jpDaysAfterLaunch,
-				enDaysToRelease,
-				enReleaseDate: formatDate(enReleaseDate),
-			};
-		});
-	})();
+		return {
+			grotto: grotto.level,
+			jpDate: formatDate(new Date(grotto.jpDate)),
+			jpDaysAfterLaunch,
+			enDaysToRelease,
+			enReleaseDate: formatDate(enReleaseDate),
+		};
+	});
 
 	// Shards in Shop
 	const shardColumns = [
@@ -185,23 +179,21 @@
 			sort: "default"
 		}
 	];
-	const shardData = (() => {
-		return jpContentHistory.shardsInShop.map(shard => {
-			const jpDaysAfterLaunch = Math.round((new Date(shard.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
-			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+	const shardData = jpContentHistory.shardsInShop.map(shard => {
+		const jpDaysAfterLaunch = Math.round((new Date(shard.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
-			return {
-				character: shard.name,
-				shop: shopDisplayNames[shard.shop],
-				jpDate: formatDate(new Date(shard.jpDate)),
-				jpDaysAfterLaunch,
-				enDaysToRelease,
-				enReleaseDate: formatDate(enReleaseDate),
-			};
-		});
-	})();
+		return {
+			character: shard.name,
+			shop: shopDisplayNames[shard.shop],
+			jpDate: formatDate(new Date(shard.jpDate)),
+			jpDaysAfterLaunch,
+			enDaysToRelease,
+			enReleaseDate: formatDate(enReleaseDate),
+		};
+	});
 
 	// Arena Shuffles
 	const arenaShuffleColumns = [
@@ -230,22 +222,20 @@
 			sort: "default"
 		}
 	];
-	const arenaShuffleData = (() => {
-		return jpContentHistory.arenaShuffle.map(arenaShuffle => {
-			const jpDaysAfterLaunch = Math.round((new Date(arenaShuffle.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
-			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+	const arenaShuffleData = jpContentHistory.arenaShuffle.map(arenaShuffle => {
+		const jpDaysAfterLaunch = Math.round((new Date(arenaShuffle.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
-			return {
-				name: getArenaName(arenaShuffle.type),
-				jpDate: formatDate(new Date(arenaShuffle.jpDate)),
-				jpDaysAfterLaunch,
-				enDaysToRelease,
-				enReleaseDate: formatDate(enReleaseDate),
-			};
-		});
-	})();
+		return {
+			name: getArenaName(arenaShuffle.type),
+			jpDate: formatDate(new Date(arenaShuffle.jpDate)),
+			jpDaysAfterLaunch,
+			enDaysToRelease,
+			enReleaseDate: formatDate(enReleaseDate),
+		};
+	});
 
 
 	// Furniture
@@ -275,22 +265,20 @@
 			sort: "default"
 		}
 	];
-	const furnitureLevelData = (() => {
-		return jpContentHistory.furnitureLevelCap.map(furnitureLevel => {
-			const jpDaysAfterLaunch = Math.round((new Date(furnitureLevel.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
-			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+	const furnitureLevelData = jpContentHistory.furnitureLevelCap.map(furnitureLevel => {
+		const jpDaysAfterLaunch = Math.round((new Date(furnitureLevel.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+		const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+		const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
-			return {
-				furnitureLevelCap: furnitureLevel.level,
-				jpDate: formatDate(new Date(furnitureLevel.jpDate)),
-				jpDaysAfterLaunch,
-				enDaysToRelease,
-				enReleaseDate: formatDate(enReleaseDate),
-			};
-		});
-	})();
+		return {
+			furnitureLevelCap: furnitureLevel.level,
+			jpDate: formatDate(new Date(furnitureLevel.jpDate)),
+			jpDaysAfterLaunch,
+			enDaysToRelease,
+			enReleaseDate: formatDate(enReleaseDate),
+		};
+	});
 
 
 </script>

--- a/src/routes/jp-history/ranks-levels-areas.svelte
+++ b/src/routes/jp-history/ranks-levels-areas.svelte
@@ -1,6 +1,7 @@
 <script>
 	import { jpContentHistory } from "@src/data/priconnedb";
-	import { formatDate } from "@src/utils";
+	import { enScheduleOffset } from "@src/settings.js";
+	import { formatDate, determineOffsetWord } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
@@ -8,7 +9,7 @@
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
 	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
-	$: data = getData();
+	$: data = getData($enScheduleOffset.quest);
 
 	let columns = [
 		{
@@ -48,7 +49,7 @@
 		}
 	];
 
-	function getData() {
+	function getData(offset = $enScheduleOffset.quest) {
 		let contentDates = {};
 		jpContentHistory.levelCap.forEach(function(cap) {
 			contentDates[cap.jpDate] = { level: cap.level };
@@ -61,13 +62,11 @@
 			contentDates[rank.jpDate].questArea = rank.questArea;
 		});
 
-
-
 		let rows = [];
 		for (let date in contentDates) {
 			const jpDaysAfterLaunch = Math.round((new Date(date) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + offset;
 			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 			rows.push({
 				maxLevel: contentDates[date].level || "–",
@@ -86,6 +85,7 @@
 <h2>JP Player Level, Equipment Rank, and Quest Area Timeline</h2>
 
 <JPContentHeader />
+<p>This page assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.quest)}</strong> by <strong>{Math.abs($enScheduleOffset.quest)}</strong> days.</p>
 
 <DopeAssTable data={data} columns={columns} scroll={false} />
 

--- a/src/routes/jp-history/ranks-levels-areas.svelte
+++ b/src/routes/jp-history/ranks-levels-areas.svelte
@@ -1,34 +1,50 @@
 <script>
 	import { jpContentHistory } from "@src/data/priconnedb";
+	import { formatDate } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
 
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
+	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
 	$: data = getData();
 
 	let columns = [
 		{
+			html: true,
 			attr: "maxLevel",
-			displayName: "Max Player Level",
+			displayName: "Max<br/>Player<br/>Level",
 			sort: "numeric"
 		}, {
+			html: true,
 			attr: "rank",
-			displayName: "Max Equipment Rank",
+			displayName: "Max<br/>Equipment<br/>Rank",
 			sort: "default"
 		}, {
+			html: true,
 			attr: "area",
-			displayName: "Furthest Quest Area",
+			displayName: "Furthest<br/>Quest<br/>Area",
 			sort: "numeric"
 		}, {
 			attr: "jpDate",
 			displayName: "JP Release Date",
 			sort: "default"
 		}, {
+			html: true,
 			attr: "jpDaysAfterLaunch",
-			displayName: "Days After JP Launch",
+			displayName: "Days since<br/>JP Launch",
 			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN<br/>Release Date",
+			sort: "default"
 		}
 	];
 
@@ -45,14 +61,22 @@
 			contentDates[rank.jpDate].questArea = rank.questArea;
 		});
 
+
+
 		let rows = [];
-		for (var date in contentDates) {
+		for (let date in contentDates) {
+			const jpDaysAfterLaunch = Math.round((new Date(date) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 			rows.push({
-				maxLevel: contentDates[date].level || "-",
-				rank: contentDates[date].rank || "-",
-				area: contentDates[date].questArea || "-",
-				jpDate: date,
-				jpDaysAfterLaunch: Math.round((new Date(date) - jpLaunchDate) / 1000 / 60 / 60 / 24)
+				maxLevel: contentDates[date].level || "–",
+				rank: contentDates[date].rank || "–",
+				area: contentDates[date].questArea || "–",
+				jpDate: formatDate(new Date(date)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
 			});
 		}
 		return rows;

--- a/src/routes/jp-history/six-stars.svelte
+++ b/src/routes/jp-history/six-stars.svelte
@@ -1,7 +1,8 @@
 <script>
 	import { jpContentHistory } from "@src/data";
 	import { getUnitImg } from "@src/logic";
-	import { escAttr, formatDate } from "@src/utils";
+	import { enScheduleOffset } from "@src/settings.js";
+	import { escAttr, formatDate, determineOffsetWord } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
@@ -9,7 +10,7 @@
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
 	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
-	$: data = getData();
+	$: data = getData($enScheduleOffset.sixStars);
 
 	let columns = [
 		{
@@ -43,7 +44,7 @@
 		}
 	];
 
-	function getData() {
+	function getData(offset = $enScheduleOffset.sixStars) {
 		let unitsAdded = jpContentHistory.sixStar;
 		return unitsAdded.map(function(unitAdded) {
 			let iconHtml = "";
@@ -53,7 +54,7 @@
 
 			const jpDaysAfterLaunch = Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + offset;
 			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 			return {
@@ -71,6 +72,7 @@
 <h2>JP Six Star Upgrade Timeline</h2>
 
 <JPContentHeader />
+<p>This page assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.sixStars)}</strong> by <strong>{Math.abs($enScheduleOffset.sixStars)}</strong> days.</p>
 
 <DopeAssTable data={data} columns={columns} scroll={false} />
 

--- a/src/routes/jp-history/six-stars.svelte
+++ b/src/routes/jp-history/six-stars.svelte
@@ -1,12 +1,13 @@
 <script>
 	import { jpContentHistory } from "@src/data";
 	import { getUnitImg } from "@src/logic";
-	import { escAttr} from "@src/utils";
+	import { escAttr, formatDate } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
 
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
+	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
 	$: data = getData();
 
@@ -25,9 +26,20 @@
 			displayName: "JP Release Date",
 			sort: "default"
 		}, {
+			html: true,
 			attr: "jpDaysAfterLaunch",
-			displayName: "Days After JP Launch",
+			displayName: "Days since<br/>JP Launch",
 			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN<br/>Release Date",
+			sort: "default"
 		}
 	];
 
@@ -38,12 +50,19 @@
 			if (unitAdded.unitId > -1) {
 				iconHtml = "<img class=\"table-icon\" src=\"" + escAttr(getUnitImg(unitAdded.unitId, { rarity: 6, server: "jp" })) + "\" />";
 			}
-			
+
+			const jpDaysAfterLaunch = Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
 			return {
 				icon: iconHtml,
 				name: unitAdded.name,
-				jpDate: unitAdded.jpDate,
-				jpDaysAfterLaunch: Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)
+				jpDate: formatDate(new Date(unitAdded.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
 			}
 		});
 	}

--- a/src/routes/jp-history/unique-equipment.svelte
+++ b/src/routes/jp-history/unique-equipment.svelte
@@ -1,7 +1,8 @@
 <script>
 	import { jpContentHistory } from "@src/data/priconnedb";
 	import { getUnitImg } from "@src/logic";
-	import { escAttr,formatDate } from "@src/utils";
+	import { enScheduleOffset } from "@src/settings.js";
+	import { escAttr, formatDate, determineOffsetWord } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
@@ -9,7 +10,7 @@
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
 	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
-	$: data = getData();
+	$: data = getData($enScheduleOffset.uniqueEquipment);
 
 	let columns = [
 		{
@@ -43,7 +44,7 @@
 		}
 	];
 
-	function getData() {
+	function getData(offset = $enScheduleOffset.uniqueEquipment) {
 		let unitsAdded = jpContentHistory.uniqueEquipment;
 		return unitsAdded.map(function(unitAdded) {
 			let iconHtml = "";
@@ -53,7 +54,7 @@
 
 			const jpDaysAfterLaunch = Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
 			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
-			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch + offset;
 			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
 
 			return {
@@ -71,6 +72,7 @@
 <h2>JP Unique Equipment Timeline</h2>
 
 <JPContentHeader />
+<p>This page assumes EN schedule is <strong>{determineOffsetWord($enScheduleOffset.uniqueEquipment)}</strong> by <strong>{Math.abs($enScheduleOffset.uniqueEquipment)}</strong> days.</p>
 
 <DopeAssTable data={data} columns={columns} scroll={false} />
 

--- a/src/routes/jp-history/unique-equipment.svelte
+++ b/src/routes/jp-history/unique-equipment.svelte
@@ -1,12 +1,13 @@
 <script>
 	import { jpContentHistory } from "@src/data/priconnedb";
 	import { getUnitImg } from "@src/logic";
-	import { escAttr} from "@src/utils";
+	import { escAttr,formatDate } from "@src/utils";
 	import DopeAssTable from "@src/components/DopeAssTable.svelte";
 	import JPContentHeader from "@src/components/JPContentHeader.svelte";
 	import JPContentFooter from "@src/components/JPContentFooter.svelte";
 
 	const jpLaunchDate = new Date(jpContentHistory.jpLaunchDate);
+	const enLaunchDate = new Date(jpContentHistory.enLaunchDate);
 
 	$: data = getData();
 
@@ -25,9 +26,20 @@
 			displayName: "JP Release Date",
 			sort: "default"
 		}, {
+			html: true,
 			attr: "jpDaysAfterLaunch",
-			displayName: "Days After JP Launch",
+			displayName: "Days since<br/>JP Launch",
 			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enDaysToRelease",
+			displayName: "Days to<br/>EN Release",
+			sort: "numeric"
+		}, {
+			html: true,
+			attr: "enReleaseDate",
+			displayName: "Expected EN<br/>Release Date",
+			sort: "default"
 		}
 	];
 
@@ -38,12 +50,19 @@
 			if (unitAdded.unitId > -1) {
 				iconHtml = "<img class=\"table-icon\" src=\"" + escAttr(getUnitImg(unitAdded.unitId, { rarity: 3, server: "jp" })) + "\" />";
 			}
-			
+
+			const jpDaysAfterLaunch = Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysAfterLaunch = Math.round((Date.now() - enLaunchDate) / 1000 / 60 / 60 / 24);
+			const enDaysToRelease = jpDaysAfterLaunch - enDaysAfterLaunch;
+			const enReleaseDate = new Date((Date.now() + (enDaysToRelease * 1000 * 60 * 60 * 24)));
+
 			return {
 				icon: iconHtml,
 				name: unitAdded.name,
-				jpDate: unitAdded.jpDate,
-				jpDaysAfterLaunch: Math.round((new Date(unitAdded.jpDate) - jpLaunchDate) / 1000 / 60 / 60 / 24)
+				jpDate: formatDate(new Date(unitAdded.jpDate)),
+				jpDaysAfterLaunch,
+				enDaysToRelease,
+				enReleaseDate: formatDate(enReleaseDate),
 			}
 		});
 	}

--- a/src/settings.js
+++ b/src/settings.js
@@ -9,7 +9,7 @@ export const theme = localStorageStore("theme", "light");
 export const enScheduleOffset = localStorageStore("enScheduleOffset", {
 	banner: 15,
 	quest: -12,
-	feature: 0,
+	feature: 28,
 	dungeon: 1,
 	grotto: 0,
 	shards: -9,

--- a/src/settings.js
+++ b/src/settings.js
@@ -6,6 +6,19 @@ export const hideImpossibleRarities = localStorageStore("hideImpossibleRarities"
 export const dataSource = localStorageStore("dataSource", "en-latest");
 export const theme = localStorageStore("theme", "light");
 
+export const enScheduleOffset = localStorageStore("enScheduleOffset", {
+	banner: 15,
+	quest: -12,
+	feature: 0,
+	dungeon: 1,
+	grotto: 0,
+	shards: -9,
+	arenaShuffle: 25,
+	furnitureLevelCap: 0,
+	sixStars: 0,
+	uniqueEquipment: 0,
+});
+
 // remember which analysis the user was looking at when switching back
 // export const lastAnalysis = localStorageStore("lastAnalysis", "");
 // export const lastGuide = localStorageStore("lastGuide", "");

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ export function shortNumber(number) {
 		shortenedNumber /= 1000;
 		index++;
 	}
-	// We're rounding to three decimals; 
+	// We're rounding to three decimals;
 	// if the abbreviation is k, it doesn't make any sense to abbreviate unless there are no decimals
 	if (index === 1 && Math.round(shortenedNumber) !== shortenedNumber) {
 		return number + "";
@@ -43,4 +43,13 @@ export function round(number, decimalPlaces) {
 
 export function escAttr(attrValue) {
 	return attrValue.replace(/'/g, "&#x27;").replace(/"/g, "&#x22;")
+}
+
+export function formatDate(dateObj) {
+	const locale = "en-gb";
+	const options = {
+		dateStyle: "long",
+	};
+	return new Intl.DateTimeFormat(locale, options).format(dateObj)
+	// return dateObj.toISOString().split('T')[0];
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,3 +53,7 @@ export function formatDate(dateObj) {
 	return new Intl.DateTimeFormat(locale, options).format(dateObj)
 	// return dateObj.toISOString().split('T')[0];
 }
+
+export function determineOffsetWord(offset) {
+	return (offset < 0) ? "ahead" : "behind";
+}


### PR DESCRIPTION
This PR requires https://github.com/Andu2/pricalc/pull/11. It adds:
- `enScheduleOffset` object to the settings, configurable in the settings page
  - This object contains numbers of days to offset the expected en release dates in the `jp-history/*` pages
  - There is an offset key for each table
  - Some of these offsets are currently defaulted to match the last content release date with the actual date in EN Priconne
    - It's only banner, quest (world), dungeon, arena shuffle, and shop shards
- They are used in all the `jp-history/*` pages to offset the expected EN release dates